### PR TITLE
Updated node-pre-gyp for wider Node 10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "nan": "^2.5.1",
-    "node-pre-gyp": "^0.10.0"
+    "node-pre-gyp": "^0.11.0"
   },
   "deprecated": false,
   "description": "based on v8-profiler@5.7.0, solved the v8-profiler segment fault error in node 8.x",
@@ -58,5 +58,5 @@
     "release": "node ./tools/release.js $@",
     "test": "mocha --debug"
   },
-  "version": "6.0.0"
+  "version": "6.0.1"
 }


### PR DESCRIPTION
Our Jenkins CI would not correctly build `v8-profiler-node8`. Narrowing it down it to 10.3/10.4 (V8 66 > 67) differences. Upgrade the use of `node-pre-gyp` to be more inclusive of Node.js v10.x.