### PR TITLE
[WIP] Restructure module for thread safety using context aware initialization

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,7 @@
         'src/profiler.cc',
         'src/cpu_profiler.cc',
         'src/cpu_profile.cc',
+        'src/profiler_data.cc',
         'src/cpu_profile_node.cc',
         'src/heap_profiler.cc',
         'src/heap_snapshot.cc',

--- a/src/cpu_profile.h
+++ b/src/cpu_profile.h
@@ -2,19 +2,18 @@
 #define NODE_PROFILE_
 
 #include "v8-profiler.h"
+#include "profiler_data.h"
 #include "nan.h"
 
 namespace nodex {
 
   class Profile {
    public:
-    static v8::Local<v8::Value> New(const v8::CpuProfile* node);
-    static Nan::Persistent<v8::Object> profiles;
+    static v8::Local<v8::Value> New(ProfilerData* data, const v8::CpuProfile* node);
    private:
     static NAN_METHOD(Delete);
-    static void Initialize();
-    static Nan::Persistent<v8::ObjectTemplate> profile_template_;
-    static uint32_t uid_counter;
+    static void Initialize(ProfilerData* data);
+    static uint32_t uid_counter; // TODO - is this going to cause thread safety issues?
   };
 
 } //namespace nodex

--- a/src/cpu_profiler.h
+++ b/src/cpu_profiler.h
@@ -2,13 +2,14 @@
 #define NODE_CPU_PROFILER_
 
 #include "v8-profiler.h"
+#include "profiler_data.h"
 #include "node.h"
 #include "nan.h"
 
 namespace nodex {
   class CpuProfiler {
     public:
-      static void Initialize(v8::Local<v8::Object> target);
+      static void Initialize(v8::Local<v8::Object> target, v8::Local<v8::Context> context, ProfilerData* data);
 
       CpuProfiler();
       virtual ~CpuProfiler();

--- a/src/heap_profiler.h
+++ b/src/heap_profiler.h
@@ -4,11 +4,12 @@
 #include "v8-profiler.h"
 #include "node.h"
 #include "nan.h"
+#include "profiler_data.h"
 
 namespace nodex {
   class HeapProfiler {
     public:
-      static void Initialize(v8::Local<v8::Object> target);
+      static void Initialize(v8::Local<v8::Object> target, v8::Local<v8::Context> context, ProfilerData* data);
 
       HeapProfiler();
       virtual ~HeapProfiler();

--- a/src/heap_snapshot.h
+++ b/src/heap_snapshot.h
@@ -3,21 +3,20 @@
 
 #include "v8-profiler.h"
 #include "nan.h"
+#include "profiler_data.h"
 
 namespace nodex {
 
   class Snapshot {
     public:
-      static v8::Local<v8::Value> New(const v8::HeapSnapshot* node);
-      static Nan::Persistent<v8::Object> snapshots;
+      static v8::Local<v8::Value> New(ProfilerData* data, const v8::HeapSnapshot* node);
     private:
-      static void Initialize();
+      static void Initialize(ProfilerData* data);
       static NAN_GETTER(GetRoot);
       static NAN_METHOD(GetNode);
       static NAN_METHOD(GetNodeById);
       static NAN_METHOD(Delete);
       static NAN_METHOD(Serialize);
-      static Nan::Persistent<v8::ObjectTemplate> snapshot_template_;
   };
 } //namespace nodex
 #endif  // NODE_SNAPSHOT_

--- a/src/profiler.cc
+++ b/src/profiler.cc
@@ -7,7 +7,7 @@
 namespace nodex {
   void InitializeProfiler(v8::Local<v8::Object> target, v8::Local<v8::Context> context, ProfilerData* data) {
     Nan::HandleScope scope;
-    HeapProfiler::Initialize(target);
+    HeapProfiler::Initialize(target, context, data);
     CpuProfiler::Initialize(target, context, data);
   }
 

--- a/src/profiler.cc
+++ b/src/profiler.cc
@@ -11,6 +11,7 @@ namespace nodex {
     CpuProfiler::Initialize(target, context, data);
   }
 
+#if (NODE_MODULE_VERSION > 0x3B)
   NODE_MODULE_INIT(/* exports, module, context */) {
     v8::Isolate* isolate = context->GetIsolate();
 
@@ -18,4 +19,16 @@ namespace nodex {
 
     InitializeProfiler(exports, context, data);
   }
+#else
+  void Initialize(v8::Local<v8::Object> exports) {
+    v8::Isolate* isolate = exports->GetIsolate();
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+
+    ProfilerData* data = new ProfilerData(context, isolate);
+
+    InitializeProfiler(exports, context, data);
+  }
+
+  NODE_MODULE(profiler, Initialize);
+#endif
 }

--- a/src/profiler.cc
+++ b/src/profiler.cc
@@ -2,13 +2,20 @@
 #include "nan.h"
 #include "heap_profiler.h"
 #include "cpu_profiler.h"
+#include "profiler_data.h"
 
 namespace nodex {
-  void InitializeProfiler(v8::Local<v8::Object> target) {
+  void InitializeProfiler(v8::Local<v8::Object> target, v8::Local<v8::Context> context, ProfilerData* data) {
     Nan::HandleScope scope;
     HeapProfiler::Initialize(target);
-    CpuProfiler::Initialize(target);
+    CpuProfiler::Initialize(target, context, data);
   }
 
-  NODE_MODULE(profiler, InitializeProfiler)
+  NODE_MODULE_INIT(/* exports, module, context */) {
+    v8::Isolate* isolate = context->GetIsolate();
+
+    ProfilerData* data = new ProfilerData(context, isolate);
+
+    InitializeProfiler(exports, context, data);
+  }
 }

--- a/src/profiler.cc
+++ b/src/profiler.cc
@@ -12,7 +12,10 @@ namespace nodex {
   }
 
 #if (NODE_MODULE_VERSION > 0x3B)
-  NODE_MODULE_INIT(/* exports, module, context */) {
+  extern "C" NODE_MODULE_EXPORT
+  void NODE_MODULE_INITIALIZER(v8::Local<v8::Object> exports,
+                          v8::Local<v8::Value> module,
+                          v8::Local<v8::Context> context) {
     v8::Isolate* isolate = context->GetIsolate();
 
     ProfilerData* data = new ProfilerData(context, isolate);

--- a/src/profiler_data.cc
+++ b/src/profiler_data.cc
@@ -7,7 +7,9 @@ namespace nodex {
 
   ProfilerData::ProfilerData(v8::Local<Context> newContext, Isolate* isolate) {
     context = newContext;
+#if (NODE_MODULE_VERSION > 0x3B)
     node::AddEnvironmentCleanupHook(isolate, DeleteInstance, this);
+#endif
   }
 
   void ProfilerData::DeleteInstance(void* data) {

--- a/src/profiler_data.cc
+++ b/src/profiler_data.cc
@@ -1,0 +1,16 @@
+#include "profiler_data.h"
+#include "node.h"
+
+namespace nodex {
+  using v8::Context;
+  using v8::Isolate;
+
+  ProfilerData::ProfilerData(v8::Local<Context> newContext, Isolate* isolate) {
+    context = newContext;
+    node::AddEnvironmentCleanupHook(isolate, DeleteInstance, this);
+  }
+
+  void ProfilerData::DeleteInstance(void* data) {
+    delete static_cast<ProfilerData*>(data);
+  }
+}

--- a/src/profiler_data.h
+++ b/src/profiler_data.h
@@ -1,0 +1,22 @@
+#ifndef PROFILER_DATA_
+#define PROFILER_DATA_
+
+#include "v8-profiler.h"
+#include "nan.h"
+
+namespace nodex {
+
+  class ProfilerData {
+   public:
+    ProfilerData(v8::Local<v8::Context> context, v8::Isolate* isolate);
+
+    v8::Local<v8::Context> context;
+    v8::CpuProfiler* profiler;
+    Nan::Persistent<v8::Object> profiles;
+    Nan::Persistent<v8::ObjectTemplate> profile_template_;
+
+    static void DeleteInstance(void* data);
+  };
+
+} //namespace nodex
+#endif // PROFILER_DATA_

--- a/src/profiler_data.h
+++ b/src/profiler_data.h
@@ -12,8 +12,12 @@ namespace nodex {
 
     v8::Local<v8::Context> context;
     v8::CpuProfiler* profiler;
+
     Nan::Persistent<v8::Object> profiles;
     Nan::Persistent<v8::ObjectTemplate> profile_template_;
+
+    Nan::Persistent<v8::Object> snapshots;
+    Nan::Persistent<v8::ObjectTemplate> snapshot_template_;
 
     static void DeleteInstance(void* data);
   };


### PR DESCRIPTION
Previously, this module would cause an error if loaded in two separate
contexts, e.g. the main thread and a worker thread.

We can use the NODE_MODULE_INIT macro to establish our module as being
context aware.

Next, we need to remove our reliance upon static shared data, especially
any v8 objects. Accessing a v8 object across isolates causes a cryptic
runtime error.

In accordance with the Node [native extensions docs](https://nodejs.org/api/addons.html#addons_context_aware_addons), we create a separate
class to store mutable data per thread, and shift all shared v8 objects
into this structure (ProfilerData).

TODO:
 - [x] Add tests
 - [x] Make heap sampling thread safe
 - [x] Extensive manual testing
 - [x] Cross version testing
 - [x] Check version `ifdef`s are still correct

I'm not a C++ dev by trade so apologies if I've made any super obvious mistakes. I'm happy to make changes based on feedback if I've taken a wrong turn somewhere.