### PR TITLE
fix: ci failed on ia32 (x86)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+# use x86_64, default is ia32
+platform:
+  - x64
+
 # Test against the latest version of this Node.js version
 environment:
   matrix:
@@ -17,7 +21,7 @@ environment:
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js or io.js
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version x64
   # install modules
   - npm install
 


### PR DESCRIPTION
It looks like a bug of the runtime itself on `ia32` (default appveyor windows VM), but usually we use is `x64`, so I set the platform:

```yml
# use x86_64, default is ia32
platform:
  - x64

# Install scripts. (runs after repo cloning)
install:
  # Get the latest stable version of Node.js or io.js
  - ps: Install-Product node $env:nodejs_version x64
```

Ref: https://github.com/hyj1991/v8-profiler-node8/pull/18
Ref: https://github.com/hyj1991/v8-profiler-node8/pull/19