### PR TITLE
Use env var to control CpuProfilingLoggingMode

### DIFF
--- a/src/cpu_profiler.cc
+++ b/src/cpu_profiler.cc
@@ -1,3 +1,4 @@
+#include "stdlib.h"
 #include "cpu_profiler.h"
 #include "cpu_profile.h"
 
@@ -22,7 +23,15 @@ namespace nodex {
 
     Local<External> externalData = Nan::New<External>(data);
 
-#if (NODE_MODULE_VERSION > 0x0039)
+#if (NODE_MODULE_VERSION > 0x0043)
+    v8::CpuProfilingLoggingMode loggingMode = v8::kLazyLogging;
+
+    if (getenv("V8_PROFILER_EAGER_LOGGING")) {
+      loggingMode = v8::kEagerLogging;
+    }
+
+    data->profiler = v8::CpuProfiler::New(context->GetIsolate(), v8::kDebugNaming, loggingMode);
+#elif (NODE_MODULE_VERSION > 0x0039)
     data->profiler = v8::CpuProfiler::New(context->GetIsolate());
 #endif
 


### PR DESCRIPTION
Previously, Node 12+ would always use the default kLazyLogging. This
means that if no profiles are running, starting a new one will cause a
possibly large delay (250ms+).

Setting CpuProfilingLoggingMode to kEagerLogging trades some upfront CPU
performance for consistently low delays when starting profiles, which
improves overall performance when starting and stopping profiles
constantly.

This is an implementation of option 2 from #24, but as stated there I'm open to any way of tackling this.