### PR TITLE
Fix undefined symbol CpuProfilingLoggingMode on Node 12.0 -> 12.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,14 +56,14 @@
     "url": "git://github.com/hyj1991/v8-profiler-node8.git"
   },
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build",
+    "install": "node ./scripts/node-pre-gyp install --fallback-to-build",
     "preinstall": "node -e 'process.exit(0)'",
     "package": "node scripts/build.js",
     "pack-common": "node scripts/common.js",
     "pack-6u": "node scripts/6u.js",
     "pack-7u": "node scripts/7u.js",
     "copy": "node scripts/copy.js",
-    "build": "node-pre-gyp rebuild",
+    "build": "node ./scripts/node-pre-gyp rebuild",
     "pack": "node-pre-gyp package && node-pre-gyp testpackage",
     "dep": "npm run build && npm run test",
     "test": "mocha"

--- a/scripts/node-pre-gyp.js
+++ b/scripts/node-pre-gyp.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+"use strict";
+
+const os = require("os");
+const fs = require("fs");
+const path = require("path");
+const cp = require("child_process");
+
+const packageJson = require("../package.json");
+const missingSymbolBinaryPath = "/node-12-missing-symbol";
+
+function debug(message) {
+  console.log(`\n\x1b[32;1m${message}\x1b[0m\n`);
+}
+
+function execCmd(cmd, env) {
+  debug(cmd);
+  cp.execSync(cmd, {
+    env,
+    cwd: path.join(__dirname, "../"),
+    stdio: "inherit",
+  });
+}
+
+function versionIsMissingSymbol() {
+  const version = process.versions.node.split(".").map((v) => parseInt(v, 10));
+  const major = version[0];
+  const minor = version[1];
+
+  return major === 12 && minor < 16;
+}
+
+function runNodePreGyp() {
+  const env = Object.assign({}, process.env);
+
+  if (versionIsMissingSymbol()) {
+    env.npm_config_profiler_binary_host_mirror =
+      packageJson.binary.host + missingSymbolBinaryPath;
+  }
+
+  const cmd = "node-pre-gyp " + process.argv.join(' ');
+
+  execCmd(cmd, env);
+}
+
+runNodePreGyp();

--- a/src/cpu_profiler.cc
+++ b/src/cpu_profiler.cc
@@ -37,16 +37,20 @@ namespace nodex {
     Local<String> title = Nan::To<String>(info[0]).ToLocalChecked();
 
 #if (NODE_MODULE_VERSION > 0x0043)
-    v8::CpuProfilingLoggingMode loggingMode = v8::kLazyLogging;
-
-    if (getenv("V8_PROFILER_EAGER_LOGGING")) {
-      loggingMode = v8::kEagerLogging;
-    }
-
     ProfilerData* data =
       reinterpret_cast<ProfilerData*>(info.Data().As<External>()->Value());
     if (!data->profiler) {
+#if (NODE_MAJOR_VERSION >= 12 && NODE_MINOR_VERSION >= 16)
+      v8::CpuProfilingLoggingMode loggingMode = v8::kLazyLogging;
+
+      if (getenv("V8_PROFILER_EAGER_LOGGING")) {
+        loggingMode = v8::kEagerLogging;
+      }
+
       data->profiler = v8::CpuProfiler::New(data->isolate_, v8::kDebugNaming, loggingMode);
+#else
+      data->profiler = v8::CpuProfiler::New(data->isolate_);
+#endif
     }
     ++data->m_startedProfilesCount;
     ++data->m_profilesSinceLastCleanup;


### PR DESCRIPTION
Applies the suggested change from #27 to only include the `CpuProfilingLoggingMode` on Node 12.16+.

There is a problem though, which is that `node-pre-gyp` does not expose the Node version for substitution in the `binary` field in the package.json. The major/minor/patch mentioned in #27 correspond to the module version unfortunately.

I have a proposed fix, which is to wrap `node-pre-gyp`, and change the binary host mirror path depending on the Node version. This means that Node v12.0 -> v12.15 will attempt to download from `https://github.com/hyj1991/v8-profiler-node8/releases/download/node-12-missing-symbol`.

This stops the impacted versions from getting the wrong binary, and will currently cause them to fallback to build.

I wasn't sure what your process for publishing binaries is, but do you think it could be adapted to do a special build for Node 12.15 that is published to the `node-12-missing-symbol` subdirectory?

If you let me know what the process is I am happy to do all the grunt work. If we can do that all versions of Node will be able to install a prebuilt binary with the correct code.