### PR TITLE
Improve performance after memory leak fix

### DIFF
--- a/src/profiler_data.h
+++ b/src/profiler_data.h
@@ -13,6 +13,7 @@ namespace nodex {
     uint32_t samplingInterval = 0;
 
     int m_startedProfilesCount = 0;
+    int m_profilesSinceLastCleanup = 0;
 
     v8::CpuProfiler* profiler = nullptr;
 


### PR DESCRIPTION
Previously, if only running a single profile at a time, we would
recreate the CpuProfiler each time. This can cause a noticeable slowdown
with small profiles, up to 15x slower than the prior version.

With this change, we only recreate the profiler after a thousand
profiles have been captured. This avoids the constant overhead of
recreating the profiler while still occasionally recreating the profiler
to reclaim memory.