### PR TITLE
Add support for Node 15 and 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,6 @@ node_js:
   - "12"
   - "13"
   - "14"
+  - "15"
+  - "16"
 script: npm run test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
     - nodejs_version: "12"
     - nodejs_version: "13"
     - nodejs_version: "14"
+    - nodejs_version: "15"
+    - nodejs_version: "16"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     }
   ],
   "dependencies": {
+    "@mapbox/node-pre-gyp": "^1.0.5",
     "nan": "^2.14.1",
-    "node-gyp": "^3.8.0",
-    "node-pre-gyp": "^0.15.0"
+    "node-gyp": "^3.8.0"
   },
   "deprecated": false,
   "description": "based on v8-profiler@5.7.0, solved the v8-profiler segment fault error in node 8.x+",

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const fs = require('fs');
-const versioning = require('node-pre-gyp/lib/util/versioning.js');
+const versioning = require('@mapbox/node-pre-gyp/lib/util/versioning.js');
 const packagePath = versioning.evaluate(require('../package.json')).staged_tarball;
 
 function copy() {

--- a/test/binding.js
+++ b/test/binding.js
@@ -1,5 +1,5 @@
 const expect  = require('chai').expect,
-      binary = require('node-pre-gyp'),
+      binary = require('@mapbox/node-pre-gyp'),
       path = require('path'),
       binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json'))),
       binding = require(binding_path);

--- a/tools/prepublish-to-npm.js
+++ b/tools/prepublish-to-npm.js
@@ -2,7 +2,7 @@
 
 const co = require('co');
 const rimraf = require('rimraf');
-const gyp = require('node-pre-gyp');
+const gyp = require('@mapbox/node-pre-gyp');
 const versions = ['0.10.0', '0.12.0', '4.0.0', '5.0.0', '6.0.0'];
 const matrix = {
   x64: ['win32', 'linux', 'darwin'],

--- a/v8-profiler.js
+++ b/v8-profiler.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var binary = require('node-pre-gyp');
+var binary = require('@mapbox/node-pre-gyp');
 var bindingPath = binary.find(path.resolve(path.join(__dirname, './package.json')));
 var binding = require(bindingPath);
 


### PR DESCRIPTION
This was quite simple, I just needed to replace node-pre-gyp with @mapbox/node-pre-gyp since node-pre-gyp is now deprecated.